### PR TITLE
Add attribute "id" to sensor entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For example:
   - id
   - timestamp
 - alarm
+  - id
   - text
   - date
   - address

--- a/custom_components/divera/connector.py
+++ b/custom_components/divera/connector.py
@@ -89,6 +89,7 @@ class DiveraData:
             alarm = self.data["data"]["alarm"]["items"][str(last_alarm_id)]
             groups = map(self.__search_group, alarm["group"])
             return {
+                "id": alarm["id"],
                 "text": alarm["text"],
                 "date": datetime.fromtimestamp(alarm["date"]),
                 "address": alarm["address"],


### PR DESCRIPTION
Today we had an alarm, where the alarm "title" (Stichwort) was changed multiple times, as I'm using the "title" (Stichwort) as the trigger of my automation, the automation was triggered multiple times. I actual don't know, if this will happen again in the future.
 The "alarm id" in divera was the same all over the time, so there was just **one** alarm in divera.

To prevent that my automation is trigged multiple times I would like to add the divera "alarm-id" as an attribute to entity `sensor.divera_alarm`, so I can use the id as a trigger in the future.

I hope you understand my usecase. 