### PR TITLE
Fix blueprint import error

### DIFF
--- a/divera-blueprint.yaml
+++ b/divera-blueprint.yaml
@@ -35,9 +35,12 @@ blueprint:
         action: {}
 mode: parallel
 max: 10
+
+variables:
+  self_addressed: !input self_addressed
 trigger:
   - platform: state
-    entity_id: !input 'divera_sensor'
+    entity_id: !input divera_sensor
     not_to:
     - unknown
     - !input 'abort_keyword'
@@ -45,12 +48,11 @@ condition:
   - condition: or
     conditions:
       - condition: template
-        value_template: {{ not self_addressed }}
+        value_template: "{{ is_state(self_addressed, 'off') }}"
       - condition: state
-        entity_id: !input 'divera_sensor'
+        entity_id: !input divera_sensor
         attribute: self_addressed
         state: true
 action:
-  - 
   - choose:
-    default: !input 'target_action'
+    default: !input target_action


### PR DESCRIPTION
As mentioned in https://github.com/fwmarcel/home-assistant-divera/issues/36 it is not possible to import the newest blueprint.

I fixed the errors inside the blueprint. The import works fine now. 
Sadly I can't test the blueprint itself, because there are less alarms in my fire department