### PR TITLE
fix: Change Blueprint trigger to "id"

### DIFF
--- a/divera-blueprint.yaml
+++ b/divera-blueprint.yaml
@@ -15,7 +15,7 @@ blueprint:
           integration: divera
           domain:
             - sensor
-          multiple: false
+          multiple: true
     self_addressed:
       name: Self addressed
       description: Check if I was addressed myself

--- a/divera-blueprint.yaml
+++ b/divera-blueprint.yaml
@@ -13,11 +13,12 @@ blueprint:
       selector:
         entity:
           integration: divera
-          domain: sensor
+          domain:
+            - sensor
           multiple: false
     self_addressed:
-      name: "Self addressed"
-      description: "Check if I was addressed myself"
+      name: Self addressed
+      description: Check if I was addressed myself
       selector:
         boolean: {}
       default: true
@@ -30,9 +31,10 @@ blueprint:
       selector:
         text:
           multiline: false
+          multiple: false
     target_action:
       name: Action
-      description: What should be done, when a new divera alarm is triggered?
+      description: What should be done, when a new divera alarm is trigged?
       selector:
         action: {}
 mode: parallel
@@ -42,18 +44,28 @@ variables:
 trigger:
   - platform: state
     entity_id: !input divera_sensor
+    attribute: id
     not_to:
       - unknown
-      - !input "abort_keyword"
+
 condition:
-  - condition: or
-    conditions:
-      - condition: template
-        value_template: "{{ is_state(self_addressed, 'off') }}"
-      - condition: state
-        entity_id: !input divera_sensor
-        attribute: self_addressed
-        state: true
+  condition: and
+  conditions:
+    - condition: not
+      conditions:
+        - condition: state
+          entity_id: !input divera_sensor
+          state:
+            - !input abort_keyword
+            - unknown
+    - condition: or
+      conditions:
+        - condition: template
+          value_template: "{{ not self_addressed }}"
+        - condition: state
+          entity_id: !input divera_sensor
+          attribute: self_addressed
+          state: true
 action:
   - choose:
     default: !input target_action

--- a/divera-blueprint.yaml
+++ b/divera-blueprint.yaml
@@ -9,7 +9,7 @@ blueprint:
   input:
     divera_sensor:
       name: Divera sensor
-      description: The sensor which show the current alarm state
+      description: The sensor which show the current divera alarm state
       selector:
         entity:
           integration: divera
@@ -34,7 +34,7 @@ blueprint:
           multiple: false
     target_action:
       name: Action
-      description: What should be done, when a new divera alarm is trigged?
+      description: What should be done, when a new divera alarm is triggered?
       selector:
         action: {}
 mode: parallel


### PR DESCRIPTION
In this PR, I would like to change the blueprint trigger to "id". This change avoids the blueprint being triggered incorrectly.

For example, when the alarm is renamed (e.g., FEU -> FEU 2) or when you have the same alarm type repeated after some time (e.g., BMA -> BMA).

I tested this blueprint for several weeks. I hope there aren't any bugs.