### PR TITLE
fix: vehicle attributes

### DIFF
--- a/custom_components/divera/sensor.py
+++ b/custom_components/divera/sensor.py
@@ -89,10 +89,10 @@ async def async_setup_entry(
                     },
                     icon="mdi:fire-truck",
                     value_fn=lambda divera, vid=vehicle_id: divera.get_vehicle_state(
-                        vehicle_id  # noqa: B023
+                        vid  # noqa: B023
                     ),
                     attribute_fn=lambda divera,
-                    vid=vehicle_id: divera.get_vehicle_attributes(vehicle_id),  # noqa: B023
+                    vid=vehicle_id: divera.get_vehicle_attributes(vid),  # noqa: B023
                 ),
             )
             entities.append(vehicle_entity)


### PR DESCRIPTION
Hello,

I just noticed that that the attributes of the vehicles are mixed up in the current release.

For example on the vehicle sensor of a "Drehleiter" I see the attributes from a "Mannschaftstransportfahrzeug"
Maybe the state of the sensor is also mixed up.

With this PR I like to fix this issue.

BTW. The vehicle sensors aren't mentioned in the latest release notes.